### PR TITLE
Fixed typo in 2023-08-17-kuijk23a.md

### DIFF
--- a/_posts/2023-08-17-kuijk23a.md
+++ b/_posts/2023-08-17-kuijk23a.md
@@ -17,7 +17,7 @@ abstract: "UCI WorldTour races, the premier men’s elite road\r cycling tour, a
   jackknife+, jackknife-minmax,\r jackknife-minmax-after-bootstrap, CV+, CV-minmax,\r
   conformalized quantile regression, and inductive\r conformal prediction methods
   in conformal prediction\r reveals that all methods achieve valid prediction\r intervals.
-  All but minmax-based methods also produce\r produce sufficiently narrow prediction
+  All but minmax-based methods also produce\r sufficiently narrow prediction
   intervals for\r decision-making. Furthermore, methods computing\r prediction intervals
   of fixed size produce tighter\r intervals for low significance values.  Among the\r
   methods computing intervals of varying length across\r the input space, inductive


### PR DESCRIPTION
Fixed typo where produce was written twice "All but min-max based mathods also produce produce..." in the abstract. This typo is not present in the easy chair submission but must have been added accidentally when my co-authors and I added the editors names. We would also like to update the pdf file of the paper in the proceedings with the fixed pdf attached to this pull request.

Thank you in advance and let me know if you need more from my side!

Regards,
Kristian van Kuijk

[COPA_paper_calorie_prediction_fixed_typo.pdf](https://github.com/mlresearch/v204/files/12642768/COPA_paper_calorie_prediction_fixed_typo.pdf)
